### PR TITLE
Removed lib from the package path

### DIFF
--- a/ngx_lua_datadog_TEMPLATE.rockspec
+++ b/ngx_lua_datadog_TEMPLATE.rockspec
@@ -13,6 +13,6 @@ dependencies = {}
 build = {
    type = "builtin",
    modules = {
-      ["lib.ngx_lua_datadog"] = "lib/ngx_lua_datadog.lua"
+      ["ngx_lua_datadog"] = "lib/ngx_lua_datadog.lua"
    }
 }


### PR DESCRIPTION
This was causing us to have to do `require "lib/ngx_lua_datadog"` rather than just `require "ngx_lua_datadog"`